### PR TITLE
Correção para o uso de proxy

### DIFF
--- a/libs/NFe/ToolsNFePHP.class.php
+++ b/libs/NFe/ToolsNFePHP.class.php
@@ -4561,11 +4561,11 @@ class ToolsNFePHP extends CommonNFePHP
             $oCurl = curl_init();
             if (is_array($this->aProxy)) {
                 curl_setopt($oCurl, CURLOPT_HTTPPROXYTUNNEL, 1);
-                curl_setopt($oCurl, CURLOPT_PROXYTYPE, "CURLPROXY_HTTP");
+                curl_setopt($oCurl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
                 curl_setopt($oCurl, CURLOPT_PROXY, $this->aProxy['IP'].':'.$this->aProxy['PORT']);
                 if ($this->aProxy['PASS'] != '') {
                     curl_setopt($oCurl, CURLOPT_PROXYUSERPWD, $this->aProxy['USER'].':'.$this->aProxy['PASS']);
-                    curl_setopt($oCurl, CURLOPT_PROXYAUTH, "CURLAUTH_BASIC");
+                    curl_setopt($oCurl, CURLOPT_PROXYAUTH, CURLAUTH_BASIC);
                 } //fim if senha proxy
             }//fim if aProxy
             curl_setopt($oCurl, CURLOPT_CONNECTTIMEOUT, $this->soapTimeout);


### PR DESCRIPTION
As constantes CURLPROXY_HTTP e CURLAUTH_BASIC estavam sendo passadas como string.
Foi removido as "" (aspas duplas) para que o php identifica-se como constante e o valor dela setados nas devidas variáveis do curl.